### PR TITLE
Remove hard dependency on GNU

### DIFF
--- a/src/olvm.c
+++ b/src/olvm.c
@@ -266,8 +266,10 @@ __attribute__((used)) const char copyright[] = "@(#)(c) 2014-2018 Yuriy Chumak";
 #endif
 
 #ifdef __linux__
-# ifndef __EMSCRIPTEN__
+# if !defined ( __EMSCRIPTEN__ ) && HAS_CDEFS
 #	include <sys/cdefs.h>
+# endif
+# if !defined ( __EMSCRIPTEN__ )
 #	include <sched.h> // yield
 # endif
 #endif


### PR DESCRIPTION
This lets otus-lisp compile more easily on machines that don't necessarily use or have GCC, GNU utilities, GNU libc, for example Linux systems built on Clang/LLVM/Musl, or other unices not related to GNU/Linux

