### PR TITLE
Do not use __builtin math. Allow compilation with TCC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ jni/gl2es/
 jni/gl4es/
 jni/GLU/
 jni/SOIL/
+#======
+ol
+vm

--- a/src/olvm.c
+++ b/src/olvm.c
@@ -1229,7 +1229,12 @@ __attribute__((used)) const char copyright[] = "@(#)(c) 2014-2022 Yuriy Chumak";
 #include <alloca.h> // we have own win32 implementation
 
 #ifndef __GNUC__
+#if defined(__TINYC__) && defined(__riscv)
+// TCC does not have alloca support for RISC-V as of 2022-12
+#define __builtin_alloca malloc
+#else
 #define __builtin_alloca alloca
+#endif
 #endif
 
 #include <errno.h>

--- a/src/olvm.c
+++ b/src/olvm.c
@@ -4847,36 +4847,36 @@ loop:;
 		A2 = (word) new_alloc(TINEXACT, sizeof(inexact_t));
 		switch (fn) {
 		case 0xFA: // fsqrt
-			*(inexact_t*)&car(A2) = __builtin_sqrt(a);
+			*(inexact_t*)&car(A2) = sqrt(a);
 			break;
 		case 0xFE: // fsin
-			*(inexact_t*)&car(A2) = __builtin_sin(a);
+			*(inexact_t*)&car(A2) = sin(a);
 			break;
 		case 0xFF: // fcos
-			*(inexact_t*)&car(A2) = __builtin_cos(a);
+			*(inexact_t*)&car(A2) = cos(a);
 			break;
 		case 0xF2: // ftan
-			*(inexact_t*)&car(A2) = __builtin_tan(a);
+			*(inexact_t*)&car(A2) = tan(a);
 			break;
 		case 0xF3: // fatan
-			*(inexact_t*)&car(A2) = __builtin_atan(a);
+			*(inexact_t*)&car(A2) = atan(a);
 			break;
 		case 0xF1: // flog
-			*(inexact_t*)&car(A2) = __builtin_log(a);
+			*(inexact_t*)&car(A2) = log(a);
 			break;
 
 		case 0x81: // fexp
-			*(inexact_t*)&car(A2) = __builtin_exp(a);
+			*(inexact_t*)&car(A2) = exp(a);
 			break;
 		case 0x8E: // fasin
-			*(inexact_t*)&car(A2) = __builtin_asin(a);
+			*(inexact_t*)&car(A2) = asin(a);
 			break;
 		case 0x8F: // facos
-			*(inexact_t*)&car(A2) = __builtin_acos(a);
+			*(inexact_t*)&car(A2) = acos(a);
 			break;
 
 		case 0xFC: // ffloor
-			*(inexact_t*)&car(A2) = __builtin_floor(a);
+			*(inexact_t*)&car(A2) = floor(a);
 			break;
 
 		default:
@@ -4914,14 +4914,14 @@ loop:;
 			break;
 	#if OLVM_BUILTIN_FMATH
 		case 0xF3: // fatan2
-			*(inexact_t*)&car(A3) = __builtin_atan2(a, b);
+			*(inexact_t*)&car(A3) = atan2(a, b);
 			break;
 		case 0xF1: // flog2
-			*(inexact_t*)&car(A3) = __builtin_log(a) / __builtin_log(b);
+			*(inexact_t*)&car(A3) = log(a) / log(b);
 			break;
 
 		case 0x81: // fexpt
-			*(inexact_t*)&car(A3) = __builtin_pow(a, b);
+			*(inexact_t*)&car(A3) = pow(a, b);
 			break;
 	#endif
 		default:


### PR DESCRIPTION
The use of __builtin_ procedures for math operations should not really be needed. Compilers are smart enough to detect the built-in mathematical operations and they can use the more optimised procedures internally.

This change also allows Ol to be compiled with TCC in x86*, as TCC does not understand (have the definitions) of the __builtin_ procedures.

More patches are needed to allow the compilation of Ol with TCC in RISC-V targets (which I have already done, I just need to submit the patches).

Thank you for your time. Best regards,
Fer

EDIT: these two commits would allow the compilation of the vm and ol using the "advance" method. The GNUmakefile would still need to be patched.